### PR TITLE
Security: remove hardcoded credentials from dev properties

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,7 +1,7 @@
 # Database
 spring.datasource.url=jdbc:mysql://localhost:3306/digital_id?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=UTC
 spring.datasource.username=root
-spring.datasource.password=password
+spring.datasource.password=${DB_PASSWORD:}
 
 # HikariCP connection pool (dev)
 spring.datasource.hikari.pool-name=digital-id-dev-pool
@@ -19,13 +19,13 @@ server.port=8080
 # Mail
 spring.mail.host=smtp.gmail.com
 spring.mail.port=587
-spring.mail.username=${MAIL_USERNAME:digitalid80@gmail.com}
-spring.mail.password=${MAIL_PASSWORD:trteibcpxgytrrjd}
+spring.mail.username=${MAIL_USERNAME:}
+spring.mail.password=${MAIL_PASSWORD:}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 
-app.mail.from-address=digitalid80@gmail.com
-app.mail.from-name=DigitalId
+app.mail.from-address=${MAIL_FROM_ADDRESS:no-reply@localhost}
+app.mail.from-name=${MAIL_FROM_NAME:DigitalId}
 
 # Frontend URL
 app.frontend.url=http://localhost:3000


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- removes hardcoded database password from `application-dev.properties`
- removes hardcoded mail username fallback and app-password fallback from dev config
- replaces static sender identity with environment-driven properties and safe local fallback

## Related issue
- closes #242

## Changes
- `spring.datasource.password` now uses `DB_PASSWORD` with empty default
- `spring.mail.username` now uses `MAIL_USERNAME` with empty default
- `spring.mail.password` now uses `MAIL_PASSWORD` with empty default
- `app.mail.from-address` and `app.mail.from-name` now use env vars (`MAIL_FROM_ADDRESS`, `MAIL_FROM_NAME`)

## Notes
- This keeps local/dev behavior configurable without committing secrets to source control.
- Existing prod config remains unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb48b60d-784e-4b70-b56e-438e27d630f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb48b60d-784e-4b70-b56e-438e27d630f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

